### PR TITLE
Bust the browser cache on updates

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,7 +16,7 @@ module.exports = (env, options) => {
   return {
     output: {
       path: path.join(__dirname, 'public'),
-      filename: 'bundle.js',
+      filename: '[name].[contenthash].js',
     },
     module: {
       rules: [


### PR DESCRIPTION
Add a hash to all bundle filenames to ensure we load a fresh set of logic on every release.